### PR TITLE
survive encountering bundles without a symbolic name

### DIFF
--- a/com.swookiee.tools.client/META-INF/MANIFEST.MF
+++ b/com.swookiee.tools.client/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1404303523335
-Build-Jdk: 1.8.0_05
-Built-By: lpfannenschmidt
+Bnd-LastModified: 1420794058463
+Build-Jdk: 1.8.0
+Built-By: tkruger1
 Bundle-Description: Swookiee REST Service Tooling build
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-ManifestVersion: 2

--- a/com.swookiee.tools.client/src/main/java/com/swookiee/tools/client/SwookieeClient.java
+++ b/com.swookiee.tools.client/src/main/java/com/swookiee/tools/client/SwookieeClient.java
@@ -189,6 +189,10 @@ public final class SwookieeClient implements AutoCloseable {
     private boolean uninstallIfInstalled(String bundleSymbolicName) throws SwookieeClientException {
         List<BundleRepresentation> installedBundles = getInstalledBundles();
         for (BundleRepresentation bundleRepresentation : installedBundles) {
+            if (bundleRepresentation.getSymbolicName() == null) {
+                logger.warn("found installed bundle which has no symbolic name: "+bundleRepresentation.getLocation());
+                continue;
+            }
             if (bundleRepresentation.getSymbolicName().equals(bundleSymbolicName)) {
                 long bundleId = bundleRepresentation.getId();
                 uninstallBundle(bundleId);


### PR DESCRIPTION
Sometimes, an accidentally installed jar file is not a proper bundle. In these cases, it has no symbolic name, and the code stumbles over it when trying to access it, giving a NPE. This snippet prints a warning and lets things move on.
